### PR TITLE
feat(ingestion) Add ability to rollback ingestion from UI - BE PR

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -119,6 +119,7 @@ import com.linkedin.datahub.graphql.resolvers.ingest.execution.CreateIngestionEx
 import com.linkedin.datahub.graphql.resolvers.ingest.execution.CreateTestConnectionRequestResolver;
 import com.linkedin.datahub.graphql.resolvers.ingest.execution.GetIngestionExecutionRequestResolver;
 import com.linkedin.datahub.graphql.resolvers.ingest.execution.IngestionSourceExecutionRequestsResolver;
+import com.linkedin.datahub.graphql.resolvers.ingest.execution.RollbackIngestionResolver;
 import com.linkedin.datahub.graphql.resolvers.ingest.secret.CreateSecretResolver;
 import com.linkedin.datahub.graphql.resolvers.ingest.secret.DeleteSecretResolver;
 import com.linkedin.datahub.graphql.resolvers.ingest.secret.GetSecretValuesResolver;
@@ -280,6 +281,7 @@ import static graphql.Scalars.*;
 public class GmsGraphQLEngine {
 
     private final EntityClient entityClient;
+    private final EntityClient restliEntityClient;
     private final GraphClient graphClient;
     private final UsageClient usageClient;
     private final SiblingGraphService siblingGraphService;
@@ -358,6 +360,7 @@ public class GmsGraphQLEngine {
 
     public GmsGraphQLEngine(
         final EntityClient entityClient,
+        final EntityClient _restliEntityClient,
         final GraphClient graphClient,
         final UsageClient usageClient,
         final AnalyticsService analyticsService,
@@ -376,6 +379,7 @@ public class GmsGraphQLEngine {
         final SiblingGraphService siblingGraphService, final GroupService groupService) {
 
         this.entityClient = entityClient;
+        this.restliEntityClient = _restliEntityClient;
         this.graphClient = graphClient;
         this.usageClient = usageClient;
         this.siblingGraphService = siblingGraphService;
@@ -756,7 +760,7 @@ public class GmsGraphQLEngine {
             .dataFetcher("createNativeUserInviteToken", new CreateNativeUserInviteTokenResolver(this.nativeUserService))
             .dataFetcher("createNativeUserResetToken", new CreateNativeUserResetTokenResolver(this.nativeUserService))
             .dataFetcher("batchUpdateSoftDeleted", new BatchUpdateSoftDeletedResolver(this.entityService))
-
+            .dataFetcher("rollbackIngestion", new RollbackIngestionResolver(this.restliEntityClient))
         );
     }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -281,7 +281,6 @@ import static graphql.Scalars.*;
 public class GmsGraphQLEngine {
 
     private final EntityClient entityClient;
-    private final EntityClient restliEntityClient;
     private final GraphClient graphClient;
     private final UsageClient usageClient;
     private final SiblingGraphService siblingGraphService;
@@ -360,7 +359,6 @@ public class GmsGraphQLEngine {
 
     public GmsGraphQLEngine(
         final EntityClient entityClient,
-        final EntityClient restliEntityClient,
         final GraphClient graphClient,
         final UsageClient usageClient,
         final AnalyticsService analyticsService,
@@ -379,7 +377,6 @@ public class GmsGraphQLEngine {
         final SiblingGraphService siblingGraphService, final GroupService groupService) {
 
         this.entityClient = entityClient;
-        this.restliEntityClient = restliEntityClient;
         this.graphClient = graphClient;
         this.usageClient = usageClient;
         this.siblingGraphService = siblingGraphService;
@@ -760,7 +757,7 @@ public class GmsGraphQLEngine {
             .dataFetcher("createNativeUserInviteToken", new CreateNativeUserInviteTokenResolver(this.nativeUserService))
             .dataFetcher("createNativeUserResetToken", new CreateNativeUserResetTokenResolver(this.nativeUserService))
             .dataFetcher("batchUpdateSoftDeleted", new BatchUpdateSoftDeletedResolver(this.entityService))
-            .dataFetcher("rollbackIngestion", new RollbackIngestionResolver(this.restliEntityClient))
+            .dataFetcher("rollbackIngestion", new RollbackIngestionResolver(this.entityClient))
         );
     }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -360,7 +360,7 @@ public class GmsGraphQLEngine {
 
     public GmsGraphQLEngine(
         final EntityClient entityClient,
-        final EntityClient _restliEntityClient,
+        final EntityClient restliEntityClient,
         final GraphClient graphClient,
         final UsageClient usageClient,
         final AnalyticsService analyticsService,
@@ -379,7 +379,7 @@ public class GmsGraphQLEngine {
         final SiblingGraphService siblingGraphService, final GroupService groupService) {
 
         this.entityClient = entityClient;
-        this.restliEntityClient = _restliEntityClient;
+        this.restliEntityClient = restliEntityClient;
         this.graphClient = graphClient;
         this.usageClient = usageClient;
         this.siblingGraphService = siblingGraphService;

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/RollbackIngestionResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/RollbackIngestionResolver.java
@@ -1,0 +1,44 @@
+package com.linkedin.datahub.graphql.resolvers.ingest.execution;
+
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.exception.AuthorizationException;
+import com.linkedin.datahub.graphql.generated.RollbackIngestionInput;
+import com.linkedin.datahub.graphql.resolvers.ingest.IngestionAuthUtils;
+import com.linkedin.entity.client.EntityClient;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+
+import java.util.concurrent.CompletableFuture;
+
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
+
+public class RollbackIngestionResolver implements DataFetcher<CompletableFuture<Boolean>> {
+  private final EntityClient _entityClient;
+
+  public RollbackIngestionResolver(final EntityClient entityClient) {
+    _entityClient = entityClient;
+  }
+
+  @Override
+  public CompletableFuture<Boolean> get(final DataFetchingEnvironment environment) throws Exception {
+    final QueryContext context = environment.getContext();
+
+    return CompletableFuture.supplyAsync(() -> {
+
+      if (!IngestionAuthUtils.canManageIngestion(context)) {
+        throw new AuthorizationException("Unauthorized to perform this action. Please contact your DataHub administrator.");
+      }
+
+      final RollbackIngestionInput input = bindArgument(environment.getArgument("input"), RollbackIngestionInput.class);
+      final String runId = input.getRunId();
+
+      try {
+        _entityClient.rollbackIngestion(runId, context.getAuthentication());
+        return true;
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to rollback ingestion execution", e);
+      }
+    });
+  }
+
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/RollbackIngestionResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/RollbackIngestionResolver.java
@@ -32,12 +32,15 @@ public class RollbackIngestionResolver implements DataFetcher<CompletableFuture<
       final RollbackIngestionInput input = bindArgument(environment.getArgument("input"), RollbackIngestionInput.class);
       final String runId = input.getRunId();
 
-      try {
-        _entityClient.rollbackIngestion(runId, context.getAuthentication());
+      CompletableFuture.supplyAsync(() -> {
+          try {
+              _entityClient.rollbackIngestion(runId, context.getAuthentication());
+              return true;
+          } catch (Exception e) {
+            throw new RuntimeException("Failed to rollback ingestion execution", e);
+          }
+        });
         return true;
-      } catch (Exception e) {
-        throw new RuntimeException("Failed to rollback ingestion execution", e);
-      }
     });
   }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/RollbackIngestionResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/RollbackIngestionResolver.java
@@ -32,16 +32,21 @@ public class RollbackIngestionResolver implements DataFetcher<CompletableFuture<
       final RollbackIngestionInput input = bindArgument(environment.getArgument("input"), RollbackIngestionInput.class);
       final String runId = input.getRunId();
 
-      CompletableFuture.supplyAsync(() -> {
-          try {
-              _entityClient.rollbackIngestion(runId, context.getAuthentication());
-              return true;
-          } catch (Exception e) {
-            throw new RuntimeException("Failed to rollback ingestion execution", e);
-          }
-        });
-        return true;
+      rollbackIngestion(runId, context);
+      return true;
     });
+  }
+
+  public CompletableFuture<Boolean> rollbackIngestion(final String runId, final QueryContext context) {
+    return CompletableFuture.supplyAsync(() -> {
+      try {
+        _entityClient.rollbackIngestion(runId, context.getAuthentication());
+        return true;
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to rollback ingestion execution", e);
+      }
+    });
+
   }
 
 }

--- a/datahub-graphql-core/src/main/resources/ingestion.graphql
+++ b/datahub-graphql-core/src/main/resources/ingestion.graphql
@@ -72,6 +72,11 @@ extend type Mutation {
   input: Input required for creating a test connection request
   """
   createTestConnectionRequest(input: CreateTestConnectionRequestInput!): String
+
+  """
+  Rollback a specific ingestion execution run based on its runId
+  """
+  rollbackIngestion(input: RollbackIngestionInput!): String
 }
 
 """
@@ -544,3 +549,14 @@ type SecretValue {
   """
   value: String!
 }
+
+"""
+Input for rolling back an ingestion execution
+"""
+input RollbackIngestionInput {
+  """
+  An ingestion run ID
+  """
+  runId: String!
+}
+

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/RollbackIngestionResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/RollbackIngestionResolverTest.java
@@ -1,13 +1,9 @@
 package com.linkedin.datahub.graphql.resolvers.ingest.execution;
 
 import com.datahub.authentication.Authentication;
-import com.linkedin.common.AuditStamp;
 import com.linkedin.datahub.graphql.QueryContext;
-import com.linkedin.datahub.graphql.generated.CreateTestConnectionRequestInput;
 import com.linkedin.datahub.graphql.generated.RollbackIngestionInput;
 import com.linkedin.entity.client.EntityClient;
-import com.linkedin.metadata.config.IngestionConfiguration;
-import com.linkedin.mxe.MetadataChangeProposal;
 import graphql.schema.DataFetchingEnvironment;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/RollbackIngestionResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/RollbackIngestionResolverTest.java
@@ -1,0 +1,82 @@
+package com.linkedin.datahub.graphql.resolvers.ingest.execution;
+
+import com.datahub.authentication.Authentication;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.CreateTestConnectionRequestInput;
+import com.linkedin.datahub.graphql.generated.RollbackIngestionInput;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.config.IngestionConfiguration;
+import com.linkedin.mxe.MetadataChangeProposal;
+import graphql.schema.DataFetchingEnvironment;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static com.linkedin.datahub.graphql.resolvers.ingest.IngestTestUtils.*;
+import static org.testng.Assert.*;
+
+
+public class RollbackIngestionResolverTest {
+
+  private static final String RUN_ID = "testRunId";
+  private static final RollbackIngestionInput TEST_INPUT = new RollbackIngestionInput(RUN_ID);
+
+  @Test
+  public void testGetSuccess() throws Exception {
+    // Create resolver
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    RollbackIngestionResolver resolver = new RollbackIngestionResolver(mockClient);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    resolver.get(mockEnv).get();
+
+    Mockito.verify(mockClient, Mockito.times(1)).rollbackIngestion(
+        Mockito.eq(RUN_ID),
+        Mockito.any(Authentication.class)
+    );
+  }
+
+  @Test
+  public void testGetUnauthorized() throws Exception {
+    // Create resolver
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    RollbackIngestionResolver resolver = new RollbackIngestionResolver(mockClient);
+
+    // Execute resolver
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockDenyContext();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(RuntimeException.class, () -> resolver.get(mockEnv).join());
+    Mockito.verify(mockClient, Mockito.times(0)).rollbackIngestion(
+        Mockito.eq(RUN_ID),
+        Mockito.any(Authentication.class));
+  }
+
+  @Test
+  public void testGetEntityClientException() throws Exception {
+    // Create resolver
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+
+    Mockito.doThrow(RuntimeException.class).when(mockClient).rollbackIngestion(
+        Mockito.any(),
+        Mockito.any(Authentication.class));
+
+    RollbackIngestionResolver resolver = new RollbackIngestionResolver(mockClient);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(RuntimeException.class, () -> resolver.get(mockEnv).join());
+  }
+}
+

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/RollbackIngestionResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/RollbackIngestionResolverTest.java
@@ -29,12 +29,8 @@ public class RollbackIngestionResolverTest {
     Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
-    resolver.get(mockEnv).get();
-
-    Mockito.verify(mockClient, Mockito.times(1)).rollbackIngestion(
-        Mockito.eq(RUN_ID),
-        Mockito.any(Authentication.class)
-    );
+    Boolean result = resolver.get(mockEnv).get();
+    assertTrue(result);
   }
 
   @Test
@@ -56,23 +52,31 @@ public class RollbackIngestionResolverTest {
   }
 
   @Test
-  public void testGetEntityClientException() throws Exception {
-    // Create resolver
+  public void testRollbackIngestionMethod() throws Exception {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
+    RollbackIngestionResolver resolver = new RollbackIngestionResolver(mockClient);
 
+    QueryContext mockContext = getMockAllowContext();
+    resolver.rollbackIngestion(RUN_ID, mockContext).get();
+
+    Mockito.verify(mockClient, Mockito.times(1)).rollbackIngestion(
+        Mockito.eq(RUN_ID),
+        Mockito.any(Authentication.class)
+    );
+  }
+
+  @Test
+  public void testGetEntityClientException() throws Exception {
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.doThrow(RuntimeException.class).when(mockClient).rollbackIngestion(
         Mockito.any(),
         Mockito.any(Authentication.class));
 
     RollbackIngestionResolver resolver = new RollbackIngestionResolver(mockClient);
 
-    // Execute resolver
     QueryContext mockContext = getMockAllowContext();
-    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
-    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
-    assertThrows(RuntimeException.class, () -> resolver.get(mockEnv).join());
+    assertThrows(RuntimeException.class, () -> resolver.rollbackIngestion(RUN_ID, mockContext).join());
   }
 }
 

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/JavaEntityClientFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/JavaEntityClientFactory.java
@@ -1,6 +1,7 @@
 package com.linkedin.gms.factory.entity;
 
 import com.linkedin.entity.client.JavaEntityClient;
+import com.linkedin.entity.client.RestliEntityClient;
 import com.linkedin.gms.factory.kafka.DataHubKafkaProducerFactory;
 import com.linkedin.metadata.entity.DeleteEntityService;
 import com.linkedin.metadata.entity.EntityService;
@@ -52,6 +53,10 @@ public class JavaEntityClientFactory {
   @Qualifier("kafkaEventProducer")
   private EventProducer _eventProducer;
 
+  @Autowired
+  @Qualifier("restliEntityClient")
+  private RestliEntityClient _restliEntityClient;
+
   @Bean("javaEntityClient")
   public JavaEntityClient getJavaEntityClient() {
     return new JavaEntityClient(
@@ -62,6 +67,7 @@ public class JavaEntityClientFactory {
         _searchService,
         _lineageSearchService,
         _timeseriesAspectService,
-        _eventProducer);
+        _eventProducer,
+        _restliEntityClient);
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/graphql/GraphQLEngineFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/graphql/GraphQLEngineFactory.java
@@ -7,7 +7,6 @@ import com.linkedin.datahub.graphql.GmsGraphQLEngine;
 import com.linkedin.datahub.graphql.GraphQLEngine;
 import com.linkedin.datahub.graphql.analytics.service.AnalyticsService;
 import com.linkedin.entity.client.JavaEntityClient;
-import com.linkedin.entity.client.RestliEntityClient;
 import com.linkedin.gms.factory.auth.DataHubTokenServiceFactory;
 import com.linkedin.gms.factory.common.GitVersionFactory;
 import com.linkedin.gms.factory.common.IndexConventionFactory;
@@ -55,10 +54,6 @@ public class GraphQLEngineFactory {
   @Autowired
   @Qualifier("javaEntityClient")
   private JavaEntityClient _entityClient;
-
-  @Autowired
-  @Qualifier("restliEntityClient")
-  private RestliEntityClient _restliEntityClient;
 
   @Autowired
   @Qualifier("graphClient")
@@ -127,7 +122,6 @@ public class GraphQLEngineFactory {
     if (isAnalyticsEnabled) {
       return new GmsGraphQLEngine(
           _entityClient,
-          _restliEntityClient,
           _graphClient,
           _usageClient,
           new AnalyticsService(elasticClient, indexConvention),
@@ -154,7 +148,6 @@ public class GraphQLEngineFactory {
     }
     return new GmsGraphQLEngine(
         _entityClient,
-        _restliEntityClient,
         _graphClient,
         _usageClient,
         null,

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/graphql/GraphQLEngineFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/graphql/GraphQLEngineFactory.java
@@ -7,6 +7,7 @@ import com.linkedin.datahub.graphql.GmsGraphQLEngine;
 import com.linkedin.datahub.graphql.GraphQLEngine;
 import com.linkedin.datahub.graphql.analytics.service.AnalyticsService;
 import com.linkedin.entity.client.JavaEntityClient;
+import com.linkedin.entity.client.RestliEntityClient;
 import com.linkedin.gms.factory.auth.DataHubTokenServiceFactory;
 import com.linkedin.gms.factory.common.GitVersionFactory;
 import com.linkedin.gms.factory.common.IndexConventionFactory;
@@ -54,6 +55,10 @@ public class GraphQLEngineFactory {
   @Autowired
   @Qualifier("javaEntityClient")
   private JavaEntityClient _entityClient;
+
+  @Autowired
+  @Qualifier("restliEntityClient")
+  private RestliEntityClient _restliEntityClient;
 
   @Autowired
   @Qualifier("graphClient")
@@ -122,6 +127,7 @@ public class GraphQLEngineFactory {
     if (isAnalyticsEnabled) {
       return new GmsGraphQLEngine(
           _entityClient,
+          _restliEntityClient,
           _graphClient,
           _usageClient,
           new AnalyticsService(elasticClient, indexConvention),
@@ -148,6 +154,7 @@ public class GraphQLEngineFactory {
     }
     return new GmsGraphQLEngine(
         _entityClient,
+        _restliEntityClient,
         _graphClient,
         _usageClient,
         null,

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/EntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/EntityClient.java
@@ -307,4 +307,6 @@ public interface EntityClient {
 
   public void producePlatformEvent(@Nonnull String name, @Nullable String key, @Nonnull PlatformEvent event,
       @Nonnull Authentication authentication) throws Exception;
+
+  public void rollbackIngestion(@Nonnull String runId, @Nonnull Authentication authentication) throws Exception;
 }

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
@@ -13,8 +13,6 @@ import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.StringArray;
 import com.linkedin.entity.Entity;
 import com.linkedin.entity.EntityResponse;
-import com.linkedin.entity.RunsDoRollbackRequestBuilder;
-import com.linkedin.entity.RunsRequestBuilders;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.aspect.EnvelopedAspect;
 import com.linkedin.metadata.aspect.EnvelopedAspectArray;
@@ -53,7 +51,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.mail.MethodNotSupportedException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
@@ -77,7 +74,6 @@ public class JavaEntityClient implements EntityClient {
     private final TimeseriesAspectService _timeseriesAspectService;
     private final EventProducer _eventProducer;
     private final RestliEntityClient _restliEntityClient;
-    private static final RunsRequestBuilders RUNS_REQUEST_BUILDERS = new RunsRequestBuilders();
 
     @Nullable
     public EntityResponse getV2(

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
@@ -51,6 +51,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.mail.MethodNotSupportedException;
+
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -479,6 +481,12 @@ public class JavaEntityClient implements EntityClient {
         @Nonnull PlatformEvent event,
         @Nonnull Authentication authentication) throws Exception {
         _eventProducer.producePlatformEvent(name, key, event);
+    }
+
+    @SneakyThrows
+    @Override
+    public void rollbackIngestion(@Nonnull String runId, @Nonnull Authentication authentication) throws Exception {
+        throw new MethodNotSupportedException();
     }
 
     private void tryIndexRunId(Urn entityUrn, @Nullable SystemMetadata systemMetadata) {

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
@@ -13,6 +13,8 @@ import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.StringArray;
 import com.linkedin.entity.Entity;
 import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.RunsDoRollbackRequestBuilder;
+import com.linkedin.entity.RunsRequestBuilders;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.aspect.EnvelopedAspect;
 import com.linkedin.metadata.aspect.EnvelopedAspectArray;
@@ -74,6 +76,8 @@ public class JavaEntityClient implements EntityClient {
     private final LineageSearchService _lineageSearchService;
     private final TimeseriesAspectService _timeseriesAspectService;
     private final EventProducer _eventProducer;
+    private final RestliEntityClient _restliEntityClient;
+    private static final RunsRequestBuilders RUNS_REQUEST_BUILDERS = new RunsRequestBuilders();
 
     @Nullable
     public EntityResponse getV2(
@@ -483,10 +487,9 @@ public class JavaEntityClient implements EntityClient {
         _eventProducer.producePlatformEvent(name, key, event);
     }
 
-    @SneakyThrows
     @Override
     public void rollbackIngestion(@Nonnull String runId, @Nonnull Authentication authentication) throws Exception {
-        throw new MethodNotSupportedException();
+        _restliEntityClient.rollbackIngestion(runId, authentication);
     }
 
     private void tryIndexRunId(Urn entityUrn, @Nullable SystemMetadata systemMetadata) {

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
@@ -39,6 +39,8 @@ import com.linkedin.entity.EntitiesVersionedV2RequestBuilders;
 import com.linkedin.entity.Entity;
 import com.linkedin.entity.EntityArray;
 import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.RunsDoRollbackRequestBuilder;
+import com.linkedin.entity.RunsRequestBuilders;
 import com.linkedin.metadata.aspect.EnvelopedAspect;
 import com.linkedin.metadata.aspect.VersionedAspect;
 import com.linkedin.metadata.browse.BrowseResult;
@@ -86,6 +88,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
       new EntitiesVersionedV2RequestBuilders();
   private static final AspectsRequestBuilders ASPECTS_REQUEST_BUILDERS = new AspectsRequestBuilders();
   private static final PlatformRequestBuilders PLATFORM_REQUEST_BUILDERS = new PlatformRequestBuilders();
+  private static final RunsRequestBuilders RUNS_REQUEST_BUILDERS = new RunsRequestBuilders();
 
   public RestliEntityClient(@Nonnull final Client restliClient) {
     super(restliClient);
@@ -109,9 +112,9 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
 
   /**
    * Legacy! Use {#batchGetV2} instead, as this method leverages Snapshot models, and will not work
-   * for fetching entities + aspects added by Entity Registry configuration. 
+   * for fetching entities + aspects added by Entity Registry configuration.
    *
-   * Batch get a set of {@link Entity} objects by urn.  
+   * Batch get a set of {@link Entity} objects by urn.
    *
    * @param urns the urns of the entities to batch get
    * @param authentication the authentication to include in the request to the Metadata Service
@@ -149,9 +152,9 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
   }
 
   /**
-   * Batch get a set of aspects for a single entity. 
+   * Batch get a set of aspects for a single entity.
    *
-   * @param entityName the entity type to fetch 
+   * @param entityName the entity type to fetch
    * @param urns the urns of the entities to batch get
    * @param aspectNames the aspect names to batch get
    * @param authentication the authentication to include in the request to the Metadata Service
@@ -211,9 +214,9 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
   }
 
   /**
-   * Autocomplete a search query for a particular field of an entity. 
+   * Autocomplete a search query for a particular field of an entity.
    *
-   * @param entityType the entity type to autocomplete against, e.g. 'dataset' 
+   * @param entityType the entity type to autocomplete against, e.g. 'dataset'
    * @param query search query
    * @param field field of the dataset
    * @param requestFilters autocomplete filters
@@ -235,9 +238,9 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
   }
 
   /**
-   * Autocomplete a search query for a particular entity type. 
+   * Autocomplete a search query for a particular entity type.
    *
-   * @param entityType the entity type to autocomplete against, e.g. 'dataset' 
+   * @param entityType the entity type to autocomplete against, e.g. 'dataset'
    * @param query search query
    * @param requestFilters autocomplete filters
    * @param limit max number of autocomplete results
@@ -669,6 +672,13 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
     if (key != null) {
       requestBuilder.keyParam(key);
     }
+    sendClientRequest(requestBuilder, authentication);
+  }
+
+  @Override
+  public void rollbackIngestion(@Nonnull String runId, @Nonnull final Authentication authentication)
+      throws Exception {
+    final RunsDoRollbackRequestBuilder requestBuilder = RUNS_REQUEST_BUILDERS.actionRollback().runIdParam(runId).dryRunParam(false);
     sendClientRequest(requestBuilder, authentication);
   }
 }

--- a/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/BatchIngestionRunResource.java
+++ b/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/BatchIngestionRunResource.java
@@ -261,7 +261,7 @@ public class BatchIngestionRunResource extends CollectionResourceTaskTemplate<St
         _entityService.ingestProposal(proposal, new AuditStamp().setActor(UrnUtils.getUrn(Constants.SYSTEM_ACTOR)).setTime(System.currentTimeMillis()));
       }
     } catch (Exception e) {
-      log.warn(String.format("Not able to update execution result aspect with runId %s.", runId), e);
+      log.error(String.format("Not able to update execution result aspect with runId %s and new status %s.", runId, status), e);
     }
   }
 


### PR DESCRIPTION
**Merging into a feature branch on my personal Fork - will bring all the work to the main fork after FE and BE PRs both get merged**

All the backend work for allowing the user to rollback an ingestion run from the UI. Creates a new endpoint that kicks off a rollback of the ingestion run using the `runId` provided. This kick-off to start rolling back is asynchronous, so we first set the status of the request result aspect as ROLLING_BACK and then on a successful result set it to ROLLED_BACK. I have a try catch and if something fails I set it to ROLLBACK_FAILED. The FE is polling while this is all going on, waiting for a result.

I would highly suggest reviewing this ignoring whitespace since the try / catch block I added makes the BatchIngestionRunResource diff extremely hard to review.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)