### PR TITLE
feat(ui) Build skeleton + header of new embedded profile

### DIFF
--- a/datahub-web-react/src/app/ProtectedRoutes.tsx
+++ b/datahub-web-react/src/app/ProtectedRoutes.tsx
@@ -6,11 +6,16 @@ import AppConfigProvider from '../AppConfigProvider';
 import { SearchRoutes } from './SearchRoutes';
 import { EducationStepsProvider } from '../providers/EducationStepsProvider';
 import UserContextProvider from './context/UserContextProvider';
+import { PageRoutes } from '../conf/Global';
+import EmbeddedPage from './embed/EmbeddedPage';
+import { useEntityRegistry } from './useEntityRegistry';
 
 /**
  * Container for all views behind an authentication wall.
  */
 export const ProtectedRoutes = (): JSX.Element => {
+    const entityRegistry = useEntityRegistry();
+
     return (
         <AppConfigProvider>
             <UserContextProvider>
@@ -19,6 +24,13 @@ export const ProtectedRoutes = (): JSX.Element => {
                         <Layout>
                             <Switch>
                                 <Route exact path="/" render={() => <HomePage />} />
+                                {entityRegistry.getEntities().map((entity) => (
+                                    <Route
+                                        key={`${entity.getPathName()}/${PageRoutes.EMBED}`}
+                                        path={`${PageRoutes.EMBED}/${entity.getPathName()}/:urn`}
+                                        render={() => <EmbeddedPage entityType={entity.type} />}
+                                    />
+                                ))}
                                 <Route path="/*" render={() => <SearchRoutes />} />
                             </Switch>
                         </Layout>

--- a/datahub-web-react/src/app/embed/EmbeddedPage.tsx
+++ b/datahub-web-react/src/app/embed/EmbeddedPage.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { useParams } from 'react-router';
+import styled from 'styled-components/macro';
+import { useGetGrantedPrivilegesQuery } from '../../graphql/policy.generated';
+import { EntityType } from '../../types.generated';
+import { UnauthorizedPage } from '../authorization/UnauthorizedPage';
+import { VIEW_ENTITY_PAGE } from '../entity/shared/constants';
+import { decodeUrn } from '../entity/shared/utils';
+import CompactContext from '../shared/CompactContext';
+import { useEntityRegistry } from '../useEntityRegistry';
+import { useGetAuthenticatedUserUrn } from '../useGetAuthenticatedUser';
+
+const EmbeddedPageWrapper = styled.div`
+    max-height: 100%;
+    overflow: auto;
+    padding: 16px;
+`;
+
+interface RouteParams {
+    urn: string;
+}
+
+interface Props {
+    entityType: EntityType;
+}
+
+export default function EmbeddedPage({ entityType }: Props) {
+    const entityRegistry = useEntityRegistry();
+    const { urn: encodedUrn } = useParams<RouteParams>();
+    const urn = decodeUrn(encodedUrn);
+
+    const authenticatedUserUrn = useGetAuthenticatedUserUrn();
+    const { data } = useGetGrantedPrivilegesQuery({
+        variables: {
+            input: {
+                actorUrn: authenticatedUserUrn,
+                resourceSpec: { resourceType: entityType, resourceUrn: urn },
+            },
+        },
+        fetchPolicy: 'cache-first',
+    });
+
+    const privileges = data?.getGrantedPrivileges?.privileges || [];
+    const canViewEntityPage = privileges.find((privilege) => privilege === VIEW_ENTITY_PAGE);
+
+    return (
+        <CompactContext.Provider value>
+            {data && !canViewEntityPage && <UnauthorizedPage />}
+            {data && canViewEntityPage && (
+                <EmbeddedPageWrapper>{entityRegistry.renderEmbeddedProfile(entityType, urn)}</EmbeddedPageWrapper>
+            )}
+        </CompactContext.Provider>
+    );
+}

--- a/datahub-web-react/src/app/entity/Entity.tsx
+++ b/datahub-web-react/src/app/entity/Entity.tsx
@@ -167,4 +167,9 @@ export interface Entity<T> {
      * Returns the supported features for the entity
      */
     supportedCapabilities: () => Set<EntityCapabilityType>;
+
+    /**
+     * Returns the profile component to be displayed in our Chrome extension
+     */
+    renderEmbeddedProfile?: (urn: string) => JSX.Element;
 }

--- a/datahub-web-react/src/app/entity/EntityPage.tsx
+++ b/datahub-web-react/src/app/entity/EntityPage.tsx
@@ -12,6 +12,7 @@ import { useGetGrantedPrivilegesQuery } from '../../graphql/policy.generated';
 import { Message } from '../shared/Message';
 import { UnauthorizedPage } from '../authorization/UnauthorizedPage';
 import { ErrorSection } from '../shared/error/ErrorSection';
+import { VIEW_ENTITY_PAGE } from './shared/constants';
 
 interface RouteParams {
     urn: string;
@@ -52,7 +53,7 @@ export const EntityPage = ({ entityType }: Props) => {
         });
     }, [entityType, urn]);
 
-    const canViewEntityPage = privileges.find((privilege) => privilege === 'VIEW_ENTITY_PAGE');
+    const canViewEntityPage = privileges.find((privilege) => privilege === VIEW_ENTITY_PAGE);
     const showNewPage =
         entityType === EntityType.Dataset ||
         entityType === EntityType.Dashboard ||

--- a/datahub-web-react/src/app/entity/EntityRegistry.tsx
+++ b/datahub-web-react/src/app/entity/EntityRegistry.tsx
@@ -114,6 +114,12 @@ export default class EntityRegistry {
         return entity.renderPreview(PreviewType.BROWSE, data);
     }
 
+    // render the regular profile if embedded profile doesn't exist. Compact context is set to true.
+    renderEmbeddedProfile(type: EntityType, urn: string): JSX.Element {
+        const entity = validatedGet(type, this.entityTypeToEntity);
+        return entity.renderEmbeddedProfile ? entity.renderEmbeddedProfile(urn) : entity.renderProfile(urn);
+    }
+
     getLineageVizConfig<T>(type: EntityType, data: T): FetchedEntity | undefined {
         const entity = validatedGet(type, this.entityTypeToEntity);
         const genericEntityProperties = this.getGenericEntityProperties(type, data);

--- a/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
@@ -26,6 +26,7 @@ import { capitalizeFirstLetterOnly } from '../../shared/textUtil';
 import { DashboardStatsSummarySubHeader } from './profile/DashboardStatsSummarySubHeader';
 import { ChartSnippet } from '../chart/ChartSnippet';
 import { EmbedTab } from '../shared/tabs/Embed/EmbedTab';
+import EmbeddedProfile from '../shared/embed/EmbeddedProfile';
 
 /**
  * Definition of the DataHub Dashboard entity.
@@ -256,4 +257,13 @@ export class DashboardEntity implements Entity<Dashboard> {
             EntityCapabilityType.SOFT_DELETE,
         ]);
     };
+
+    renderEmbeddedProfile = (urn: string) => (
+        <EmbeddedProfile
+            urn={urn}
+            entityType={EntityType.Dashboard}
+            useEntityQuery={useGetDashboardQuery}
+            getOverrideProperties={this.getOverridePropertiesFromEntity}
+        />
+    );
 }

--- a/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
@@ -28,6 +28,7 @@ import { SidebarSiblingsSection } from '../shared/containers/profile/sidebar/Sid
 import { DatasetStatsSummarySubHeader } from './profile/stats/stats/DatasetStatsSummarySubHeader';
 import { DatasetSearchSnippet } from './DatasetSearchSnippet';
 import { EmbedTab } from '../shared/tabs/Embed/EmbedTab';
+import EmbeddedProfile from '../shared/embed/EmbeddedProfile';
 
 const SUBTYPES = {
     VIEW: 'view',
@@ -325,4 +326,13 @@ export class DatasetEntity implements Entity<Dataset> {
             EntityCapabilityType.SOFT_DELETE,
         ]);
     };
+
+    renderEmbeddedProfile = (urn: string) => (
+        <EmbeddedProfile
+            urn={urn}
+            entityType={EntityType.Dataset}
+            useEntityQuery={useGetDatasetQuery}
+            getOverrideProperties={this.getOverridePropertiesFromEntity}
+        />
+    );
 }

--- a/datahub-web-react/src/app/entity/shared/constants.ts
+++ b/datahub-web-react/src/app/entity/shared/constants.ts
@@ -77,3 +77,5 @@ export const ENTITY_TYPES_WITH_MANUAL_LINEAGE = new Set([
 ]);
 
 export const DEFAULT_SYSTEM_ACTOR_URNS = ['urn:li:corpuser:__datahub_system', 'urn:li:corpuser:unknown'];
+
+export const VIEW_ENTITY_PAGE = 'VIEW_ENTITY_PAGE';

--- a/datahub-web-react/src/app/entity/shared/embed/EmbeddedHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/embed/EmbeddedHeader.tsx
@@ -1,0 +1,96 @@
+import { Image, Typography } from 'antd';
+import React from 'react';
+import styled, { useTheme } from 'styled-components/macro';
+import Link from 'antd/lib/typography/Link';
+import { ArrowRightOutlined } from '@ant-design/icons';
+import { DEFAULT_APP_CONFIG } from '../../../../appConfigContext';
+import { useAppConfig } from '../../../useAppConfig';
+import { useEntityRegistry } from '../../../useEntityRegistry';
+import { IconStyleType } from '../../Entity';
+import { useEntityData } from '../EntityContext';
+import { getDisplayedEntityType } from '../containers/profile/header/PlatformContent/PlatformContentContainer';
+import { ANTD_GRAY } from '../constants';
+
+const HeaderWrapper = styled.div`
+    display: flex;
+`;
+
+const LogoImage = styled(Image)`
+    display: inline-block;
+    height: 40px;
+    width: auto;
+`;
+
+const EntityContent = styled.div`
+    margin-left: 16px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+`;
+
+const EntityTypeWrapper = styled.div`
+    font-size: 12px;
+    color: ${ANTD_GRAY[8]};
+`;
+
+const TypeIcon = styled.span`
+    margin-right: 5px;
+`;
+
+const EntityName = styled(Typography.Text)`
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 24px;
+`;
+
+const StyledLink = styled(Link)`
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 22px;
+    margin-left: 8px;
+`;
+
+const EntityNameWrapper = styled.div`
+    display: flex;
+    align-items: baseline;
+`;
+
+export default function EmbeddedHeader() {
+    const entityRegistry = useEntityRegistry();
+    const { entityData, entityType } = useEntityData();
+    const appConfig = useAppConfig();
+    const themeConfig = useTheme();
+
+    const typeIcon = entityRegistry.getIcon(entityType, 12, IconStyleType.ACCENT);
+    const displayedEntityType = getDisplayedEntityType(entityData, entityRegistry, entityType);
+    const entityName = entityRegistry.getDisplayName(entityType, entityData);
+    const entityTypePathName = entityRegistry.getPathName(entityType);
+    const logoUrl =
+        appConfig.config !== DEFAULT_APP_CONFIG
+            ? appConfig.config.visualConfig.logoUrl || themeConfig.assets.logoUrl
+            : undefined;
+
+    return (
+        <HeaderWrapper>
+            <LogoImage src={logoUrl} preview={false} />
+            <EntityContent>
+                <EntityTypeWrapper>
+                    <TypeIcon>{typeIcon}</TypeIcon>
+                    {displayedEntityType}
+                </EntityTypeWrapper>
+                <EntityNameWrapper>
+                    <EntityName ellipsis={{ tooltip: entityName }} style={{ maxWidth: '75%' }}>
+                        {entityName}
+                    </EntityName>
+                    <StyledLink
+                        href={`${window.location.origin}/${entityTypePathName}/${entityData?.urn}`}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                    >
+                        view in DataHub <ArrowRightOutlined />
+                    </StyledLink>
+                </EntityNameWrapper>
+            </EntityContent>
+        </HeaderWrapper>
+    );
+}

--- a/datahub-web-react/src/app/entity/shared/embed/EmbeddedProfile.tsx
+++ b/datahub-web-react/src/app/entity/shared/embed/EmbeddedProfile.tsx
@@ -1,0 +1,92 @@
+import { LoadingOutlined } from '@ant-design/icons';
+import { QueryHookOptions, QueryResult } from '@apollo/client';
+import { Divider } from 'antd';
+import React from 'react';
+import styled from 'styled-components';
+import { EntityType, Exact } from '../../../../types.generated';
+import { getDataForEntityType } from '../containers/profile/utils';
+import EntityContext from '../EntityContext';
+import { combineEntityDataWithSiblings } from '../siblingUtils';
+import { GenericEntityProperties } from '../types';
+import EmbeddedHeader from './EmbeddedHeader';
+
+const LoadingWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 85vh;
+    font-size: 50px;
+`;
+
+const StyledDivider = styled(Divider)`
+    margin: 16px 0;
+`;
+
+interface Props<T> {
+    urn: string;
+    entityType: EntityType;
+    useEntityQuery: (
+        baseOptions: QueryHookOptions<
+            T,
+            Exact<{
+                urn: string;
+            }>
+        >,
+    ) => QueryResult<
+        T,
+        Exact<{
+            urn: string;
+        }>
+    >;
+    getOverrideProperties: (T) => GenericEntityProperties;
+}
+
+export default function EmbeddedProfile<T>({ urn, entityType, getOverrideProperties, useEntityQuery }: Props<T>) {
+    const {
+        loading,
+        data: dataNotCombinedWithSiblings,
+        refetch,
+    } = useEntityQuery({
+        variables: { urn },
+    });
+
+    const dataCombinedWithSiblings = combineEntityDataWithSiblings(dataNotCombinedWithSiblings);
+
+    const entityData =
+        (dataCombinedWithSiblings &&
+            Object.keys(dataCombinedWithSiblings).length > 0 &&
+            getDataForEntityType({
+                data: dataCombinedWithSiblings[Object.keys(dataCombinedWithSiblings)[0]],
+                entityType,
+                getOverrideProperties,
+                isHideSiblingMode: false,
+            })) ||
+        null;
+
+    return (
+        <EntityContext.Provider
+            value={{
+                urn,
+                entityType,
+                entityData,
+                baseEntity: dataCombinedWithSiblings,
+                dataNotCombinedWithSiblings,
+                routeToTab: () => {},
+                refetch,
+                lineage: undefined,
+            }}
+        >
+            {loading && (
+                <LoadingWrapper>
+                    <LoadingOutlined />
+                </LoadingWrapper>
+            )}
+            {!loading && entityData && (
+                <>
+                    <EmbeddedHeader />
+                    <StyledDivider />
+                </>
+            )}
+        </EntityContext.Provider>
+    );
+}

--- a/datahub-web-react/src/conf/Global.ts
+++ b/datahub-web-react/src/conf/Global.ts
@@ -26,6 +26,7 @@ export enum PageRoutes {
     DOMAINS = '/domains',
     GLOSSARY = '/glossary',
     SETTINGS_VIEWS = '/settings/views',
+    EMBED = '/embed',
 }
 
 /**


### PR DESCRIPTION
**Merging to a feature branch**

Builds out the skeleton and header of the new embedded profile that we will show in the iframe of our chrome extension. Route to a new route that's the same as entity profiles but starts with "/embed". Implement this for Datasets and Dashboards for now.

Here's what it looks like so far:
<img width="1475" alt="image" src="https://user-images.githubusercontent.com/28656603/211219589-16e560b1-1f4c-48bd-b214-e2c4357dbe95.png">


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
